### PR TITLE
VisitXml递归时,每次传入需要处理的标签对应的XML子串

### DIFF
--- a/src/FD.Generic.Xml/Regexs/XmlTagHelper.cs
+++ b/src/FD.Generic.Xml/Regexs/XmlTagHelper.cs
@@ -12,6 +12,25 @@ namespace FD.Generic.Xml.Regexs
     public class XmlTagHelper
     {
         /// <summary>  
+        /// 获取字符中指定标签的子串  
+        /// </summary>  
+        /// <param name="content">字符串</param>  
+        /// <param name="tagName">标签</param>  
+        /// <returns>标签xml字符串</returns>  
+        public static string GetSubXmlContent(string content, string tagName, string attrib)
+        {
+            string valueStr = "([\\s\\S]*?)";
+            string tmpStr = string.IsNullOrEmpty(attrib) ? $"<{tagName}>{valueStr}</{tagName}>" :
+                $"<{tagName}\\s*{attrib}\\s*=\\s*.*?>{valueStr}</{tagName}>";
+            Match match = Regex.Match(content, tmpStr, RegexOptions.IgnoreCase);
+
+            string result = match == null ? "" : match.Groups[0].Value;
+            //Match math = Regex.Match(result, @"\<\!\[CDATA\[(?<([\s\S]*?)>[^\]]*)\]\]\>", RegexOptions.IgnoreCase);
+
+            return result;
+        }
+
+        /// <summary>  
         /// 获取字符中指定标签的值  
         /// </summary>  
         /// <param name="content">字符串</param>  

--- a/src/FD.Generic.Xml/XmlSerializer.cs
+++ b/src/FD.Generic.Xml/XmlSerializer.cs
@@ -325,6 +325,7 @@ namespace FD.Generic.Xml
         {
             foreach (var field in fields)
             {
+                string subXml = XmlTagHelper.GetSubXmlContent(xml, field.Name.FirstToLower(), "");
                 Type subType = field.PropertyType;
                 if (!subType.FullName.StartsWith("System.") && !IsEnumType(subType))
                 {
@@ -333,16 +334,16 @@ namespace FD.Generic.Xml
                     field.SetValue(obj, subObj);
                     if (subFields.Count() > 0)
                     {
-                        VisitXml(xml, subObj, subFields);
+                        VisitXml(subXml, subObj, subFields);
                     }
                     else
                     {
-                        field.SetValue(subObj, XmlTagHelper.GetTagContent(xml, field.Name.FirstToLower(), "", _needCData));
+                        field.SetValue(subObj, XmlTagHelper.GetTagContent(subXml, field.Name.FirstToLower(), "", _needCData));
                     }
                 }
                 else
                 {
-                    var value = XmlTagHelper.GetTagContent(xml, field.Name.FirstToLower(), "", _needCData);
+                    var value = XmlTagHelper.GetTagContent(subXml, field.Name.FirstToLower(), "", _needCData);
                     if (subType != typeof(string))
                     {
                         if (IsEnumType(subType))


### PR DESCRIPTION
原代码在不同标签中包含相同元素的时候，比如
            <ContractDocument>
                <ID>88031547681</ID>
            </ContractDocument>
            <AssociatedDocument>
                <ID>88031547681_SORDEA00230</ID>
            </AssociatedDocument>
会错误每次找到第一个<ID>。
